### PR TITLE
Tweet: "more" indicator for multiple photos, and playable flag

### DIFF
--- a/__tests__/integration.test.js
+++ b/__tests__/integration.test.js
@@ -2023,7 +2023,7 @@ test('fetch twitter data', async (t) => {
   t.deepEqual(result.data.embed, {
     __typename: 'TwitterEmbed',
     id: '931088218279366656',
-    text: 'What’s the manager’s message to the fans ahead of #AFCvTHFC?\n\n“Just to support the team and stand with us for the 9… https://t.co/iwipqW8UlF',
+    text: 'What’s the manager’s message to the fans ahead of #AFCvTHFC?\n\n“Just to support the team and stand with us for the 90 minutes”\n\n#WeAreTheArsenal🔴 https://t.co/GQM6lFfcVr',
     userName: 'Arsenal FC'
   })
   t.end()

--- a/graphql/resolvers/_queries/embed.js
+++ b/graphql/resolvers/_queries/embed.js
@@ -12,13 +12,13 @@ const { getVimeoVideoById } = require('../../../lib/vimeo')
 // // One capturing group at match[1] that catches the video id
 // const VIMEO_REGEX = /^(?:http|https)?:\/\/(?:www\.)?vimeo.com\/(?:channels\/(?:\w+\/)?|groups\/(?:[^/]*)\/videos\/|)(\d+)(?:|\/\?)$/
 
-module.exports = async (_, args, { user }) => {
+module.exports = async (_, args, { user, t }) => {
   ensureUserHasRole(user, 'editor')
 
   const { id, embedType } = args
 
   if (embedType === 'TwitterEmbed') {
-    const tweetData = await getTweetById(id)
+    const tweetData = await getTweetById(id, t)
 
     return {
       embedType,

--- a/graphql/schema-types.js
+++ b/graphql/schema-types.js
@@ -99,6 +99,8 @@ type TwitterEmbed implements Embed {
   userScreenName: String!
   userProfileImageUrl: String!,
   image: String
+  more: String
+  playable: Boolean!
 }
 
 type YoutubeEmbed implements Embed {

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2017-09-18T10:04:42.657Z",
+  "updated": "2017-12-01T17:33:01.287Z",
   "title": "live",
   "data": [
     {
@@ -33,6 +33,18 @@
     {
       "key": "api/github/yaml/warning",
       "value": "✋ The message contains yaml values used by Project R's CMS. Changing the values here is not supported (yet) and might result in unexpected consequences."
+    },
+    {
+      "key": "api/publish/scheduledAt/tooFarInTheFuture",
+      "value": "Sorry, the latest possible scheduling date is {days} into the future. "
+    },
+    {
+      "key": "api/twitter/morephotos/other",
+      "value": "{count} weitere Fotos"
+    },
+    {
+      "key": "api/twitter/morephotos/1",
+      "value": "1 weiteres Foto"
     }
   ]
 }

--- a/lib/twitter/index.js
+++ b/lib/twitter/index.js
@@ -4,7 +4,7 @@ const oauth = require('./oauth')
 
 let bearerToken
 
-const getTweetById = async id => {
+const getTweetById = async (id, t) => {
   if (!bearerToken) {
     bearerToken = await oauth()
   }
@@ -14,40 +14,63 @@ const getTweetById = async id => {
     {
       method: 'GET',
       headers: {
-        'Authorization': `Bearer ${bearerToken}`,
+        Authorization: `Bearer ${bearerToken}`,
         'Accept-Encoding': 'gzip'
       }
     }
   )
-  .then(res => res.json())
-  .catch(error => {
-    console.error(`Error getting tweet with id ${id}:`, error)
-    return error
-  })
+    .then(res => res.json())
+    .catch(error => {
+      console.error(`Error getting tweet with id ${id}:`, error)
+      return error
+    })
 
   if (response.errors) {
-    throw new Error(response.errors.reduce(
-      (error, { code, message }) =>
-        error.concat(` ${code}: ${message}`),
-      'Twitter API Errors:'
-    ))
+    throw new Error(
+      response.errors.reduce(
+        (error, { code, message }) => error.concat(` ${code}: ${message}`),
+        'Twitter API Errors:'
+      )
+    )
   }
+
+  // If a Tweet contains native media (shared with the Tweet user-interface as opposed
+  // via a link to elsewhere), there will also be an extended_entities section.
+  const extendedMedia =
+    (response.extended_entities && response.extended_entities.media) || []
+
+  // Twitter currently only allows
+  // 1-4 photos, or
+  // 1 video, or
+  // 1 animated GIF in one tweet.
+  const firstMedium = extendedMedia.shift()
+  const playable =
+    !!firstMedium &&
+    (firstMedium.type === 'video' || firstMedium.type === 'animated_gif')
+  const more =
+    (!!firstMedium &&
+      firstMedium.type === 'photo' &&
+      extendedMedia.length > 0 &&
+      t.pluralize('api/twitter/morephotos', {
+        count: extendedMedia.length
+      })) ||
+    undefined
 
   return {
     id: response.id_str,
     createdAt: new Date(response.created_at),
     retrievedAt: new Date(),
-    text: response.text,
-    html: Autolinker.link(response.text, {mention: 'twitter'}),
+    text: response.full_text || response.text,
+    html: Autolinker.link(response.full_text || response.text, {
+      mention: 'twitter'
+    }),
     userId: response.user.id_str,
     userName: response.user.name,
     userScreenName: response.user.screen_name,
     userProfileImageUrl: response.user.profile_image_url_https,
-    // TODO: Append any response.entities beyond the first image to html as links.
-    image: response.entities &&
-      response.entities.media &&
-      response.entities.media[0] &&
-      response.entities.media[0].media_url_https
+    image: firstMedium && firstMedium.media_url_https,
+    more: more,
+    playable: playable
   }
 }
 


### PR DESCRIPTION
Related to 
https://github.com/orbiting/publikator-frontend/pull/78
https://github.com/orbiting/styleguide/pull/51

Here's how this data will render:

## Multiple photos
<img width="508" alt="screen shot 2017-12-01 at 18 29 45" src="https://user-images.githubusercontent.com/23520051/33495519-07c3fd00-d6c7-11e7-879e-52b7027e747a.png">

## Video
<img width="510" alt="screen shot 2017-12-01 at 18 30 12" src="https://user-images.githubusercontent.com/23520051/33495521-07e1ceca-d6c7-11e7-9eb5-d506ae5db209.png">

# Animated GIF
<img width="501" alt="screen shot 2017-12-01 at 18 32 04" src="https://user-images.githubusercontent.com/23520051/33495522-08001df8-d6c7-11e7-9264-e0ccebeade86.png">
