### PR TITLE
Add repo search

### DIFF
--- a/graphql/schema-types.js
+++ b/graphql/schema-types.js
@@ -24,7 +24,7 @@ type RepoConnection {
   nodes: [Repo]
   pageInfo: PageInfo!
   totalCount: Int!
-  totalDiskUsage: Int!
+  totalDiskUsage: Int
 }
 
 type PageInfo {

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -11,6 +11,8 @@ type queries {
     last: Int
     before: String
     after: String
+    # can not be combined with orderBy
+    search: String
     orderBy: RepoOrderBy
   ): RepoConnection!
   repo(id: ID!): Repo!

--- a/lib/github/getRepos.js
+++ b/lib/github/getRepos.js
@@ -1,0 +1,240 @@
+const createGithubClients = require('./clients')
+
+const {
+  GITHUB_LOGIN
+} = process.env
+
+const fragments = `
+fragment LatestPublicationProbs on Ref {
+  name
+  target {
+    ... on Tag {
+      name
+      message
+      oid
+      author: tagger {
+        name
+        email
+        date
+      }
+      commit: target {
+        ... on Commit {
+          id: oid
+        }
+      }
+    }
+  }
+}
+fragment Repo on Repository {
+  name
+  defaultBranchRef {
+    target {
+      ... on Commit {
+        oid
+      }
+    }
+  }
+  metaTag: ref(qualifiedName: "refs/tags/meta") {
+    target {
+      ... on Tag {
+        message
+      }
+    }
+  }
+  tags: refs(refPrefix: "refs/tags/", first: 100) {
+    nodes {
+      name
+    }
+  }
+  publication: ref(qualifiedName: "refs/tags/publication") {
+    ...LatestPublicationProbs
+  }
+  prepublication: ref(qualifiedName: "refs/tags/prepublication") {
+    ...LatestPublicationProbs
+  }
+  scheduledPublication: ref(qualifiedName: "refs/tags/scheduled-publication") {
+    ...LatestPublicationProbs
+  }
+  scheduledPrepublication: ref(qualifiedName: "refs/tags/scheduled-prepublication") {
+    ...LatestPublicationProbs
+  }
+}
+`
+
+// TK: Once GraphQL supports code results
+// https://platform.github.community/t/how-to-search-code-using-graphql/1906
+// const searchQuery = ({search, ...args}) => ({
+//   query: `
+//     ${fragments}
+//     query repositories(
+//       $query: String!
+//       $first: Int
+//       $last: Int
+//       $before: String
+//       $after: String
+//     ) {
+//       search(
+//         type: REPOSITORY,
+//         first: $first,
+//         last: $last,
+//         before: $before,
+//         after: $after,
+//         query: $query
+//       ) {
+//         repositoryCount
+//         pageInfo {
+//           endCursor
+//           hasNextPage
+//           hasPreviousPage
+//           startCursor
+//         }
+//         nodes {
+//           ...on Repository {
+//             ...Repo
+//           }
+//         }
+//       }
+//     }
+//   `,
+//   variables: {
+//     ...args,
+//     query: `org:${GITHUB_LOGIN} ${search}`
+//   }
+// })
+
+const listQuery = args => ({
+  query: `
+    ${fragments}
+    query repositories(
+      $login: String!
+      $first: Int
+      $last: Int
+      $before: String
+      $after: String
+      $orderBy: RepositoryOrder
+    ) {
+      repositoryOwner(login: $login) {
+        repositories(
+          first: $first,
+          last: $last,
+          before: $before,
+          after: $after,
+          orderBy: $orderBy
+        ) {
+          pageInfo {
+            endCursor,
+            hasNextPage,
+            hasPreviousPage,
+            startCursor
+          }
+          totalCount
+          totalDiskUsage
+          nodes {
+            ...Repo
+          }
+        }
+      }
+    }
+  `,
+  variables: {
+    ...args,
+    login: GITHUB_LOGIN
+  }
+})
+
+const nameQuery = repoNames => ({
+  query: `
+    ${fragments}
+    query repositories(
+      $login: String!
+    ) {
+      repositoryOwner(login: $login) {
+        ${repoNames.map((repoName, i) => `
+          r${i}: repository(name: "${repoName}") {
+            ...Repo
+          }
+        `)}
+      }
+    }
+  `,
+  variables: {
+    login: GITHUB_LOGIN
+  }
+})
+
+module.exports = {
+  getRepos: async (args) => {
+    const { githubApolloFetch, githubRest } = await createGithubClients()
+
+    if (args.search) {
+      if (args.orderBy) {
+        throw new Error('getRepos: orderBy not supported when searching')
+      }
+      // TK: Remove once GraphQL supports code results
+      if (args.before || args.after || args.last) {
+        throw new Error('getRepos: pagination not supported when searching')
+      }
+
+      const search = await githubRest.search.code({
+        q: `org:${GITHUB_LOGIN} ${args.search}`,
+        per_page: args.first
+      })
+
+      const searchResultRepos = search.data.items
+        .map(item => item.repository)
+        .filter((a, index, all) => index === all.findIndex(b => a.id === b.id))
+
+      let repositories = []
+
+      if (searchResultRepos.length) {
+        const {
+          data: {
+            repositoryOwner
+          }
+        } = await githubApolloFetch(nameQuery(searchResultRepos.map(repo => repo.name)))
+
+        repositories = searchResultRepos.map((_, i) => repositoryOwner[`r${i}`])
+      }
+
+      // TK: Once GraphQL supports code results
+      // const {
+      //   data: {
+      //     search: {
+      //       pageInfo,
+      //       repositoryCount: totalCount,
+      //       nodes: repositories
+      //     }
+      //   }
+      // } = await githubApolloFetch(searchQuery(args))
+
+      return {
+        pageInfo: {
+          hasPreviousPage: false,
+          hasNextPage: false
+        },
+        totalCount: repositories.length,
+        repositories
+      }
+    }
+
+    const {
+      data: {
+        repositoryOwner: {
+          repositories: {
+            pageInfo,
+            totalCount,
+            totalDiskUsage,
+            nodes: repositories
+          }
+        }
+      }
+    } = await githubApolloFetch(listQuery(args))
+
+    return {
+      pageInfo,
+      totalCount,
+      totalDiskUsage,
+      repositories
+    }
+  }
+}

--- a/lib/github/index.js
+++ b/lib/github/index.js
@@ -1,5 +1,6 @@
 const createGithubClients = require('./clients')
 const { gitAuthor } = require('./utils')
+const { getRepos } = require('./getRepos')
 const uniqWith = require('lodash/uniqWith')
 
 const publicationVersionRegex = /^v(\d+)(-prepublication)?.*/
@@ -21,6 +22,7 @@ const tagNormalizer = (tag, repoId, refName) => ({
 
 module.exports = {
   gitAuthor,
+  getRepos,
   publicationVersionRegex,
   createGithubClients,
   tagNormalizer,


### PR DESCRIPTION
Powered by GitHub code search—full text search on the default branch.

Unfortunately the GraphQL api doesn't return code results (yet).

It does how ever tell you that it found something with a `codeCount` or rather `codeCunt`:
<img width="1075" alt="screen shot 2017-12-20 at 19 19 38" src="https://user-images.githubusercontent.com/410211/34224571-97f95996-e5c3-11e7-9fb6-024f2342ec96.png">

So to dodge this I'm going through rest, extracting the matching repos and then fetching them with all the meta info needed via GraphQL. No paging support ;(

Responses are between 1 and 3s. Would be twice as fast if GraphQL would work.