### PR TITLE
Softer Catch

### DIFF
--- a/graphql/resolvers/Commit.js
+++ b/graphql/resolvers/Commit.js
@@ -65,8 +65,16 @@ module.exports = {
         }
       }
 
-      mdast = MDAST.parse(repository.blob.text)
-      await redis.setAsync(redisKey, JSON.stringify(mdast))
+      try {
+        mdast = MDAST.parse(repository.blob.text)
+      } catch (e) {
+        console.error(e)
+      }
+      if (mdast) {
+        await redis.setAsync(redisKey, JSON.stringify(mdast))
+      } else {
+        mdast = MDAST.parse('Dokument fehlerhaft. Reden Sie mit der IT.')
+      }
     }
 
     // prefix image urls

--- a/graphql/resolvers/Commit.js
+++ b/graphql/resolvers/Commit.js
@@ -14,29 +14,28 @@ module.exports = {
     { oneway },
     { user, redis }
   ) => {
-    try {
-      if (existingDocument) {
-        return existingDocument
-      }
+    if (existingDocument) {
+      return existingDocument
+    }
 
-      let mdast
+    let mdast
 
-      const redisKey = `repos:${repoId}/commits/${commitId}/document/mdast`
-      const redisMdast = await redis.getAsync(redisKey)
-      if (redisMdast) {
-        debug('document: redis HIT (%s)', redisKey)
-        mdast = JSON.parse(redisMdast)
-      } else {
-        debug('document: redis MISS (%s)', redisKey)
-        const { githubApolloFetch } = await createGithubClients()
-        const [login, repoName] = repoId.split('/')
+    const redisKey = `repos:${repoId}/commits/${commitId}/document/mdast`
+    const redisMdast = await redis.getAsync(redisKey)
+    if (redisMdast) {
+      debug('document: redis HIT (%s)', redisKey)
+      mdast = JSON.parse(redisMdast)
+    } else {
+      debug('document: redis MISS (%s)', redisKey)
+      const { githubApolloFetch } = await createGithubClients()
+      const [login, repoName] = repoId.split('/')
 
-        const {
-          data: {
-            repository
-          }
-        } = await githubApolloFetch({
-          query: `
+      const {
+        data: {
+          repository
+        }
+      } = await githubApolloFetch({
+        query: `
           query document(
             $login: String!,
             $repoName: String!,
@@ -51,48 +50,39 @@ module.exports = {
             }
           }
         `,
-          variables: {
-            login,
-            repoName,
-            blobExpression: `${commitId}:article.md`
-          }
-        })
-
-        if (!repository.blob) {
-          console.warn(`no document found for ${repoId}`)
-          return {
-            content: {},
-            meta: {}
-          }
-        }
-
-        mdast = MDAST.parse(repository.blob.text)
-        await redis.setAsync(redisKey, JSON.stringify(mdast))
-      }
-
-      // prefix image urls
-      // - editor specific
-      const prefixUrl = createPrefixUrl(repoId, oneway)
-      visit(mdast, 'image', node => {
-        node.url = prefixUrl(node.url)
-      })
-      Object.keys(mdast.meta).forEach(key => {
-        if (key.match(/image/i)) {
-          mdast.meta[key] = prefixUrl(mdast.meta[key])
+        variables: {
+          login,
+          repoName,
+          blobExpression: `${commitId}:article.md`
         }
       })
 
-      return {
-        content: mdast
-      }
-    } catch (e) {
-      console.error(e)
-      return {
-        content: {
-          document: null,
-          meta: null
+      if (!repository.blob) {
+        console.warn(`no document found for ${repoId}`)
+        return {
+          content: {},
+          meta: {}
         }
       }
+
+      mdast = MDAST.parse(repository.blob.text)
+      await redis.setAsync(redisKey, JSON.stringify(mdast))
+    }
+
+    // prefix image urls
+    // - editor specific
+    const prefixUrl = createPrefixUrl(repoId, oneway)
+    visit(mdast, 'image', node => {
+      node.url = prefixUrl(node.url)
+    })
+    Object.keys(mdast.meta).forEach(key => {
+      if (key.match(/image/i)) {
+        mdast.meta[key] = prefixUrl(mdast.meta[key])
+      }
+    })
+
+    return {
+      content: mdast
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@orbiting/backend-modules-scalars": "^0.0.6",
     "@orbiting/backend-modules-scripts": "^1.0.1",
     "@orbiting/backend-modules-translate": "^0.0.0",
-    "@orbiting/remark-preset": "^1.2.1",
+    "@orbiting/remark-preset": "^1.2.2",
     "@project-r/styleguide": "^5.24.0",
     "@project-r/template-newsletter": "^1.4.3",
     "apollo-fetch": "^0.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -91,9 +91,9 @@
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/@orbiting/backend-modules-translate/-/backend-modules-translate-0.0.0.tgz#7a3cecf0d9d4590e71ac06c29971e41d9b4b70f1"
 
-"@orbiting/remark-preset@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@orbiting/remark-preset/-/remark-preset-1.2.1.tgz#b4e5f744fd27332c1215e15c08e13e15c16776c0"
+"@orbiting/remark-preset@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@orbiting/remark-preset/-/remark-preset-1.2.2.tgz#f9ce952164ef10d6197f920fb1df3eca7a9b9937"
   dependencies:
     js-yaml "^3.10.0"
     parse-entities "^1.1.1"


### PR DESCRIPTION
With the fixes in https://github.com/orbiting/publikator-frontend/pull/104 it will display the following if it can't parse the markdown:
<img width="1009" alt="screen shot 2018-01-06 at 15 59 51" src="https://user-images.githubusercontent.com/410211/34641061-77fa8e24-f2fe-11e7-8a4f-0571be85466c.png">

Additionally I'm no longer throwing when a zone hasn't ended: https://github.com/orbiting/mdast/commit/e8b547013ab08afb84a1e6c72ddd8f49eefad29f

So the document with the invalid multi paragraph `sub` will now work again and the unrecognised `sub` striped as unsupported html mdast type when deserializing in publikator.