### PR TITLE
 quick fix for missing path on resolvedDoc for editorial newsletters

### DIFF
--- a/graphql/resolvers/_mutations/publish.js
+++ b/graphql/resolvers/_mutations/publish.js
@@ -312,7 +312,13 @@ module.exports = async (
 
   // do the mailchimp update
   if (campaignId) {
+    // resolvedDoc currently has no path set.
+    resolvedDoc.content.meta = {
+      ...resolvedDoc.content.meta,
+      path: doc.content.meta.path
+    }
     const html = getHTML(resolvedDoc)
+
     const updateResponse = await updateCampaignContent({
       campaignId,
       html

--- a/graphql/resolvers/_mutations/publish.js
+++ b/graphql/resolvers/_mutations/publish.js
@@ -315,7 +315,7 @@ module.exports = async (
     // resolvedDoc currently has no path set.
     resolvedDoc.content.meta = {
       ...resolvedDoc.content.meta,
-      path: doc.content.meta.path
+      path: resolvedDoc.content.meta.path || doc.content.meta.path
     }
     const html = getHTML(resolvedDoc)
 


### PR DESCRIPTION
The links on today's editorial newsletter logo and footer ("Im Web lesen") are wrong, because the resolvedDoc's content meta only has a slug set, but no computed path. It links to `/foo` when it actually should link to `/YY/MM/dd/foo`.

Here's my quick fix, so we don't have to set up another redirect tomorrow.