### PR TITLE
youtube embed: fallback to standard thumbnail size if maxres is not available

### DIFF
--- a/lib/embeds/youtube/index.js
+++ b/lib/embeds/youtube/index.js
@@ -39,6 +39,9 @@ const getYoutubeVideoById = async id => {
       return error
     })
 
+  const thumbnails = response.items[0].snippet.thumbnails
+  const thumbnail = thumbnails.maxres ? thumbnails.maxres.url : thumbnails.standard.url
+
   return {
     platform: 'youtube',
     id: response.items[0].id,
@@ -47,7 +50,7 @@ const getYoutubeVideoById = async id => {
     title: response.items[0].snippet.title,
     userUrl: `https://www.youtube.com/channel/${channelId}`,
     userName: response.items[0].snippet.channelTitle,
-    thumbnail: response.items[0].snippet.thumbnails.maxres.url,
+    thumbnail: thumbnail,
     userProfileImageUrl: channelResponse
       ? channelResponse.items[0].snippet.thumbnails.default.url
       : '',


### PR DESCRIPTION
Fixes the server error in publikator when trying to add a video which doesn't have a maxres thumbnail.

As a next step, we need to make sure the frontend takes the video aspect ratio into account when rendering the thumbnail.

https://developers.google.com/youtube/v3/docs/thumbnails